### PR TITLE
highlight abtract/overridden functions

### DIFF
--- a/syntaxes/dascript.tmLanguage.json
+++ b/syntaxes/dascript.tmLanguage.json
@@ -434,7 +434,7 @@
     },
     "function": {
       "name": "meta.function.dascript",
-      "begin": "(def)\\s+(?=[\\w]+\\s*\\()|(\\$)\\s*(?=\\[(?:.*?)\\])|(\\$)\\s*(?=\\()",
+      "begin": "(def)(\\s+(?:abstract|override))?\\s+(?=[\\w]+\\s*\\()|(\\$)\\s*(?=\\[(?:.*?)\\])|(\\$)\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "storage.type.function.dascript"
@@ -443,6 +443,9 @@
           "name": "storage.type.function.dascript"
         },
         "3": {
+          "name": "storage.type.function.dascript"
+        },
+        "4": {
           "name": "storage.type.function.dascript"
         }
       },

--- a/syntaxes/dascript.tmLanguage.yaml
+++ b/syntaxes/dascript.tmLanguage.yaml
@@ -233,13 +233,15 @@ repository:
       - include: $self
   function:
     name: meta.function.dascript
-    begin: (def)\s+(?=[\w]+\s*\()|(\$)\s*(?=\[(?:.*?)\])|(\$)\s*(?=\()
+    begin: (def)(\s+(?:abstract|override))?\s+(?=[\w]+\s*\()|(\$)\s*(?=\[(?:.*?)\])|(\$)\s*(?=\()
     beginCaptures:
       1:
         name: storage.type.function.dascript
       2:
         name: storage.type.function.dascript
       3:
+        name: storage.type.function.dascript
+      4:
         name: storage.type.function.dascript
     end: (\))
     endCaptures:


### PR DESCRIPTION
naive implementation that doesn't different method vs function, just mark `def abstract` or `def override` as  valid syntax
![image](https://user-images.githubusercontent.com/250935/82739578-32e0fb00-9d49-11ea-9769-ae60171e2d9d.png)
