### PR TITLE
Fix incorrect coloring of the function suffixes

### DIFF
--- a/syntaxes/dascript.tmLanguage.json
+++ b/syntaxes/dascript.tmLanguage.json
@@ -434,13 +434,13 @@
     },
     "function": {
       "name": "meta.function.dascript",
-      "begin": "(def)(\\s+(?:abstract|override)(?:private|public)(?:static))?\\s+(?=[\\w]+\\s*\\()|(\\$)\\s*(?=\\[(?:.*?)\\])|(\\$)\\s*(?=\\()",
+      "begin": "(def)((?:\\s+(?:abstract|override|private|public|static))*)|(?:(?:\\s+\\S+)*)\\s+(?=[\\w]+\\s*\\()|(\\$)\\s*(?=\\[(?:.*?)\\])|(\\$)\\s*(?=\\()",
       "beginCaptures": {
         "1": {
           "name": "storage.type.function.dascript"
         },
         "2": {
-          "name": "storage.type.function.dascript"
+          "name": "keyword.control.dascript"
         },
         "3": {
           "name": "storage.type.function.dascript"

--- a/syntaxes/dascript.tmLanguage.yaml
+++ b/syntaxes/dascript.tmLanguage.yaml
@@ -234,12 +234,12 @@ repository:
       - include: $self
   function:
     name: meta.function.dascript
-    begin: (def)(\s+(?:abstract|override)(?:private|public)(?:static))?\s+(?=[\w]+\s*\()|(\$)\s*(?=\[(?:.*?)\])|(\$)\s*(?=\()
+    begin: (def)((?:\s+(?:abstract|override|private|public|static))*)|(?:(?:\s+\S+)*)\s+(?=[\w]+\s*\()|(\$)\s*(?=\[(?:.*?)\])|(\$)\s*(?=\()
     beginCaptures:
       1:
         name: storage.type.function.dascript
       2:
-        name: storage.type.function.dascript
+        name: keyword.control.dascript
       3:
         name: storage.type.function.dascript
       4:


### PR DESCRIPTION
For example `def public foo()` should now now highlight `def` as a function start, and `public` as a keyword.

Match all the available keywords, even if there are many of them. The syntax will be checked by the compiler, but the coloring shouldn't break.