### PR TITLE
Fix apostrophe in trailing comment breaking highlighting after ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dascript",
     "displayName": "daScript",
     "description": "daScript is high-performance statically strong typed scripting language, designed to be high-performance as embeddable ‘scripting’ language for real-time applications (like games).",
-    "version": "0.0.28",
+    "version": "0.0.29",
     "publisher": "eguskov",
     "license": "BSD-3-Clause",
     "icon": "daslang.png",

--- a/syntaxes/dascript.tmLanguage.json
+++ b/syntaxes/dascript.tmLanguage.json
@@ -1393,6 +1393,9 @@
       "end": "(?=\\n|\\;)",
       "patterns": [
         {
+          "include": "#comments"
+        },
+        {
           "match": ":",
           "name": "keyword.operator.ternary.dascript"
         },

--- a/syntaxes/dascript.tmLanguage.yaml
+++ b/syntaxes/dascript.tmLanguage.yaml
@@ -682,6 +682,7 @@ repository:
       0: {name: keyword.operator.ternary.dascript}
     end: (?=\n|\;)
     patterns:
+      - include: '#comments'
       - match: ':'
         name: keyword.operator.ternary.dascript
       - match: \b(is|as)\b

--- a/test/fixtures/comments.das
+++ b/test/fixtures/comments.das
@@ -40,3 +40,7 @@ function someFunc(var self : SomeType, param : int) : bool
 
 // Code with comment containing apostrophe
 clear(unsafe(reinterpret<TypeDecl?> typ.get_ptr()).dim) // It's better than declaring typ as var.
+
+struct Foo {
+    @do_not_delete ar : array<uint8>? // TODO: remove ar if it's owned by the stream
+}


### PR DESCRIPTION
The ternary_operator block runs to end of line and matched #strings but not #comments, so an apostrophe in a trailing // comment opened a single-quoted string spanning the rest of the file.