### PR TITLE
Types & general highlighting improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dascript",
     "displayName": "daScript",
     "description": "daScript is high-performance statically strong typed scripting language, designed to be high-performance as embeddable ‘scripting’ language for real-time applications (like games).",
-    "version": "0.0.30",
+    "version": "0.0.31",
     "publisher": "eguskov",
     "license": "BSD-3-Clause",
     "icon": "daslang.png",

--- a/syntaxes/dascript.tmLanguage.json
+++ b/syntaxes/dascript.tmLanguage.json
@@ -578,6 +578,9 @@
           },
           "patterns": [
             {
+              "include": "#comments"
+            },
+            {
               "include": "#qmacro_escape_sequences"
             },
             {
@@ -595,6 +598,9 @@
                 }
               },
               "patterns": [
+                {
+                  "include": "#comments"
+                },
                 {
                   "include": "#builtin_types"
                 },
@@ -665,6 +671,9 @@
           },
           "patterns": [
             {
+              "include": "#comments"
+            },
+            {
               "include": "#qmacro_escape_sequences"
             },
             {
@@ -721,6 +730,9 @@
           },
           "patterns": [
             {
+              "include": "#comments"
+            },
+            {
               "include": "#qmacro_escape_sequences"
             },
             {
@@ -742,6 +754,9 @@
               },
               "end": "(?=;|>)",
               "patterns": [
+                {
+                  "include": "#comments"
+                },
                 {
                   "name": "meta.type.auto.parameterized.variant.dascript",
                   "begin": "\\b(auto)\\s*(\\()",
@@ -815,6 +830,9 @@
             }
           },
           "patterns": [
+            {
+              "include": "#comments"
+            },
             {
               "include": "#qmacro_escape_sequences"
             },

--- a/syntaxes/dascript.tmLanguage.json
+++ b/syntaxes/dascript.tmLanguage.json
@@ -7,6 +7,9 @@
       "include": "#comments"
     },
     {
+      "include": "#function_reference"
+    },
+    {
       "include": "#annotations"
     },
     {
@@ -419,6 +422,17 @@
         }
       ]
     },
+    "function_reference": {
+      "match": "(@@)([[:alpha:]_][[:alnum:]_]*(?:::[[:alnum:]_]+)*)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.address-of-function.dascript"
+        },
+        "2": {
+          "name": "entity.name.function.dascript"
+        }
+      }
+    },
     "annotations": {
       "patterns": [
         {
@@ -602,7 +616,14 @@
                   "include": "#comments"
                 },
                 {
+                  "match": "\\b(var|let)\\b",
+                  "name": "storage.modifier.specifier.decl.dascript"
+                },
+                {
                   "include": "#builtin_types"
+                },
+                {
+                  "include": "#generic_types"
                 },
                 {
                   "include": "#module_qualified_type"
@@ -864,7 +885,7 @@
       "patterns": [
         {
           "name": "support.type.dascript",
-          "match": "(?x) (?<!\\.) \\b( bool | void | string | int | int2 | int3 | int4 | uint | uint2 | uint3 | uint4 | float | float2 | float3 | float4 | range | urange | int64 | uint64 | double | int8 | uint8 | int16 | uint16) \\b(?!(\\s*\\())"
+          "match": "(?x) (?<!\\.) \\b( bool | void | string | int | int2 | int3 | int4 | uint | uint2 | uint3 | uint4 | float | float2 | float3 | float4 | range(?!\\s*\\() | urange(?!\\s*\\() | int64 | uint64 | double | int8 | uint8 | int16 | uint16) \\b"
         },
         {
           "name": "meta.type.auto.parameterized.dascript",
@@ -988,22 +1009,19 @@
       ]
     },
     "module_qualified_type": {
-      "match": "\\b([[:alpha:]_][[:alnum:]_]*)(::)([[:alpha:]_][[:alnum:]_]*)\\b",
+      "match": "\\b([[:alpha:]_][[:alnum:]_]*)(::)",
       "captures": {
         "1": {
           "name": "entity.name.type.module.dascript"
         },
         "2": {
           "name": "punctuation.separator.namespace.dascript"
-        },
-        "3": {
-          "name": "entity.name.type.dascript"
         }
       }
     },
     "qmacro_functions": {
       "name": "meta.function-call.qmacro.dascript",
-      "match": "\\b(qmacro_block|qmacro|qmacro_function|qmacro_type|qmacro_template_class|qmacro_variable)\\b",
+      "match": "\\b(qmacro_block|qmacro_expr|qmacro|qmacro_function|qmacro_type|qmacro_template_class|qmacro_variable)\\b",
       "captures": {
         "1": {
           "name": "entity.name.function"
@@ -1108,12 +1126,12 @@
       "patterns": [
         {
           "name": "meta.qmacro-escape.dascript",
-          "begin": "(\\$)([ifevatcb])(\\()",
+          "begin": "(\\$[ifevatcb])(\\()",
           "beginCaptures": {
-            "2": {
-              "name": "keyword.control.dascript"
+            "1": {
+              "name": "storage.modifier.dascript"
             },
-            "3": {
+            "2": {
               "name": "punctuation.definition.arguments.begin.dascript"
             }
           },
@@ -1592,7 +1610,7 @@
     },
     "assignment": {
       "name": "meta.assignment.dascript",
-      "begin": "\\b(?<!typedef\\s*|\\:\\s*)([[:alpha:]_][[:alnum:]_]*)\\s*(?=\\=|\\+\\=|-\\=|\\*\\=|\\/\\=|\\&\\=|\\|\\=|\\^\\=)",
+      "begin": "\\b(?<!typedef\\s*|[^:]\\:\\s*)([[:alpha:]_][[:alnum:]_]*)\\s*(?=\\=|\\+\\=|-\\=|\\*\\=|\\/\\=|\\&\\=|\\|\\=|\\^\\=)",
       "beginCaptures": {
         "1": {
           "name": "variable.parameter.type.dascript"
@@ -1606,7 +1624,7 @@
       ]
     },
     "identifier": {
-      "match": "\\b(?<!\\:\\s*)([[:alpha:]_][[:alnum:]_]*)\\b",
+      "match": "\\b(?<![^:]\\:\\s*)([[:alpha:]_][[:alnum:]_]*)\\b",
       "name": "variable.parameter.identifier.dascript"
     },
     "typedef": {
@@ -1724,6 +1742,12 @@
                   },
                   "end": "(?=\\,|\\))",
                   "patterns": [
+                    {
+                      "include": "#builtin_types"
+                    },
+                    {
+                      "include": "#generic_types"
+                    },
                     {
                       "include": "#module_qualified_type"
                     },

--- a/syntaxes/dascript.tmLanguage.yaml
+++ b/syntaxes/dascript.tmLanguage.yaml
@@ -271,6 +271,7 @@ repository:
         endCaptures:
           1: {name: punctuation.definition.generic.end.dascript}
         patterns:
+          - include: '#comments'
           - include: '#qmacro_escape_sequences'
           - name: meta.function.signature.dascript
             begin: \(
@@ -280,6 +281,7 @@ repository:
             endCaptures:
               0: {name: punctuation.definition.parameters.end.dascript}
             patterns:
+              - include: '#comments'
               - include: '#builtin_types'
               - include: '#module_qualified_type'
               - name: meta.parameter.dascript
@@ -309,6 +311,7 @@ repository:
         endCaptures:
           1: {name: punctuation.definition.generic.end.dascript}
         patterns:
+          - include: '#comments'
           - include: '#qmacro_escape_sequences'
           - include: '#generic_types'
           - name: meta.tuple.field.dascript
@@ -333,6 +336,7 @@ repository:
         endCaptures:
           1: {name: punctuation.definition.generic.end.dascript}
         patterns:
+          - include: '#comments'
           - include: '#qmacro_escape_sequences'
           - include: '#generic_types'
           - include: '#keywords_without_operators'
@@ -343,6 +347,7 @@ repository:
               2: {name: punctuation.separator.type.dascript}
             end: (?=;|>)
             patterns:
+              - include: '#comments'
               - name: meta.type.auto.parameterized.variant.dascript
                 begin: \b(auto)\s*(\()
                 beginCaptures:
@@ -374,6 +379,7 @@ repository:
         endCaptures:
           1: {name: punctuation.definition.generic.end.dascript}
         patterns:
+          - include: '#comments'
           - include: '#qmacro_escape_sequences'
           - include: '#generic_types'
           - include: '#keywords_without_operators'

--- a/syntaxes/dascript.tmLanguage.yaml
+++ b/syntaxes/dascript.tmLanguage.yaml
@@ -3,6 +3,7 @@ name: daScript
 scopeName: source.dascript
 patterns:
   - include: '#comments'
+  - include: '#function_reference'
   - include: '#annotations'
   - include: '#struct_declaration'
   - include: '#function'
@@ -188,6 +189,12 @@ repository:
         patterns:
           - name: constant.character.escape.dascript
             match: \\.
+  function_reference:
+    # Address-of-function references: @@func, @@module::func
+    match: (@@)([[:alpha:]_][[:alnum:]_]*(?:::[[:alnum:]_]+)*)\b
+    captures:
+      1: {name: storage.modifier.address-of-function.dascript}
+      2: {name: entity.name.function.dascript}
   annotations:
     patterns:
       # Structure annotations: [match_copy], [match_as_is], [some_annotation(arg1, arg2)], etc.
@@ -282,7 +289,10 @@ repository:
               0: {name: punctuation.definition.parameters.end.dascript}
             patterns:
               - include: '#comments'
+              - match: \b(var|let)\b
+                name: storage.modifier.specifier.decl.dascript
               - include: '#builtin_types'
+              - include: '#generic_types'
               - include: '#module_qualified_type'
               - name: meta.parameter.dascript
                 match: \b([[:alpha:]_][[:alnum:]_]*)\s*(:)
@@ -398,9 +408,9 @@ repository:
           \b(
             bool | void | string | int | int2 | int3 | int4 |
             uint | uint2 | uint3 | uint4 | float | float2 |
-            float3 | float4 | range | urange | int64 | uint64 |
+            float3 | float4 | range(?!\s*\() | urange(?!\s*\() | int64 | uint64 |
             double | int8 | uint8 | int16 | uint16)
-          \b(?!(\s*\())
+          \b
       - name: meta.type.auto.parameterized.dascript
         begin: \b(auto)\s*(\()
         beginCaptures:
@@ -471,16 +481,16 @@ repository:
           - match: \b([[:alnum:]_]+)\b
             name: entity.name.type.dascript
   module_qualified_type:
-    # Matches module-qualified types like ast::TypeDecl, math::Vector3, etc.
-    # The module namespace should be highlighted as a type, not a variable
-    match: \b([[:alpha:]_][[:alnum:]_]*)(::)([[:alpha:]_][[:alnum:]_]*)\b
+    # module:: namespace prefix (ast::, math::, user::). Only the prefix is
+    # consumed; the name after it is tokenized by whatever rules apply in the
+    # surrounding context (type in type positions, variable/function in expressions)
+    match: \b([[:alpha:]_][[:alnum:]_]*)(::)
     captures:
       1: {name: entity.name.type.module.dascript}
       2: {name: punctuation.separator.namespace.dascript}
-      3: {name: entity.name.type.dascript}
   qmacro_functions:
     name: meta.function-call.qmacro.dascript
-    match: \b(qmacro_block|qmacro|qmacro_function|qmacro_type|qmacro_template_class|qmacro_variable)\b
+    match: \b(qmacro_block|qmacro_expr|qmacro|qmacro_function|qmacro_type|qmacro_template_class|qmacro_variable)\b
     captures:
       1: {name: entity.name.function}
   function_call:
@@ -529,7 +539,8 @@ repository:
           2: {name: entity.name.function}
   qmacro_escape_sequences:
     patterns:
-      # Macro reification escape sequences: $e(), $v(), $i(), $t(), $a(), $c(), $b()
+      # Macro reification escape sequences / AST matching tags:
+      # $e(), $v(), $i(), $t(), $a(), $c(), $b(), $f()
       # $e - expression substitution
       # $v - value substitution
       # $i - identifier/iterator substitution
@@ -537,13 +548,12 @@ repository:
       # $a - argument array substitution
       # $c - call name substitution
       # $b - block/expression array substitution
+      # $f - field name capture
       - name: meta.qmacro-escape.dascript
-        begin: (\$)([ifevatcb])(\()
+        begin: (\$[ifevatcb])(\()
         beginCaptures:
-          # TODO: handle tuple<$i()> correctly
-          # 1: {name: keyword.other.dascript}
-          2: {name: keyword.control.dascript}
-          3: {name: punctuation.definition.arguments.begin.dascript}
+          1: {name: storage.modifier.dascript}
+          2: {name: punctuation.definition.arguments.begin.dascript}
         end: (\))
         endCaptures:
           1: {name: punctuation.definition.arguments.end.dascript}
@@ -770,14 +780,14 @@ repository:
       - include: '#comments'
   assignment:
     name: meta.assignment.dascript
-    begin: \b(?<!typedef\s*|\:\s*)([[:alpha:]_][[:alnum:]_]*)\s*(?=\=|\+\=|-\=|\*\=|\/\=|\&\=|\|\=|\^\=)
+    begin: \b(?<!typedef\s*|[^:]\:\s*)([[:alpha:]_][[:alnum:]_]*)\s*(?=\=|\+\=|-\=|\*\=|\/\=|\&\=|\|\=|\^\=)
     beginCaptures:
       1: {name: variable.parameter.type.dascript}
     end: (?=\=|\+\=|-\=|\*\=|\/\=|\&\=|\|\=|\^\=)
     patterns:
       - include: '#comments'
   identifier:
-    match: \b(?<!\:\s*)([[:alpha:]_][[:alnum:]_]*)\b
+    match: \b(?<![^:]\:\s*)([[:alpha:]_][[:alnum:]_]*)\b
     name: variable.parameter.identifier.dascript
   typedef:
     patterns:
@@ -834,6 +844,8 @@ repository:
                   1: {name: variable.parameter.function.dascript}
                 end: (?=\,|\))
                 patterns:
+                  - include: '#builtin_types'
+                  - include: '#generic_types'
                   - include: '#module_qualified_type'
                   - match: \b([[:alnum:]_]+)\b
                     name: entity.name.type.dascript

--- a/test/fixtures/cast-types.das
+++ b/test/fixtures/cast-types.das
@@ -40,3 +40,22 @@ def test_module_qualified_declarations()
 // smart_ptr with module-qualified types (template context)
 def getCppType(typ : smart_ptr<ast::TypeDecl>&, var imports : table<string>&)
     pass
+
+// Base types called as constructor casts should highlight as types
+def test_constructor_casts()
+    let u16 = uint16(0)
+    let f = float(intValue)
+    var v = float3(1.0, 2.0, 3.0)
+
+// Module-qualified variable assignment: the member is a variable, not a type
+def test_module_qualified_assignment(userName : string)
+    user::userName = userName
+    game::score += 1
+    net::config.timeout = 5
+    net::send_message(userName)
+
+// range() is a builtin iterator function, not a constructor cast
+def test_range_call()
+    for i in range(10)
+        pass
+    var r : range

--- a/test/fixtures/function-pointers.das
+++ b/test/fixtures/function-pointers.das
@@ -13,3 +13,9 @@ handler : function<(data : array<int>, config : Config?) : void>
 struct MyStruct
     onEvent : function<(eventId : EventId) : void>
     calculate : function<(value : float) : float>
+
+// Address-of-function references
+def setup()
+    set_lobby_callbacks(@@on_lobby_created, @@on_lobby_connected, @@on_lobby_destroyed)
+    var cb = @@handler
+    subscribe(@@events::on_update)

--- a/test/fixtures/lambda-types.das
+++ b/test/fixtures/lambda-types.das
@@ -30,3 +30,6 @@ var getId : lambda<uint64>
 
 // Lambda with double return type
 var getPrecision : lambda<double>
+
+// Lambda signature with var parameter modifier and nested generic type
+var connected : lambda<(var urls : array<string>, userName : string) : void>

--- a/test/fixtures/table-types.das
+++ b/test/fixtures/table-types.das
@@ -31,3 +31,6 @@ var complex : table<NodeId, array<float>>
 // Table with builtin types
 var builtins : table<int64, double>
 var mixed : table<uint, bool>
+
+// Block comments inside generic arguments should stay comments
+var nodeNetIds : table<uint64 /*NodeId*/; uint /*netId*/>

--- a/test/suite/syntax.test.js
+++ b/test/suite/syntax.test.js
@@ -678,6 +678,26 @@ suite('daScript Syntax Highlighting Tests', () => {
             assert.ok(boolHasTypeScope, `bool should be tokenized as a type. Got scopes: ${JSON.stringify(boolScopes?.scopes)}`);
         }
 
+        // Nested generic parameter type: array<int> in function<(data : array<int>, ...)>
+        let nestedGenericLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('data : array<int>')) {
+                nestedGenericLine = i;
+                break;
+            }
+        }
+        assert.ok(nestedGenericLine >= 0, 'Should find line with data : array<int>');
+
+        const arrayPos = findInLine(document, nestedGenericLine, 'array<int>');
+        const arrayScopes = await getTokenScopesAt(document, nestedGenericLine, arrayPos.character);
+        const arrayIsKeywordType = arrayScopes?.scopes?.some(scope => scope.includes('keyword.type'));
+        assert.ok(arrayIsKeywordType, `'array' in function pointer parameter should be keyword.type. Got scopes: ${JSON.stringify(arrayScopes?.scopes)}`);
+
+        const intTypePos = findInLine(document, nestedGenericLine, 'int>');
+        const intTypeScopes = await getTokenScopesAt(document, nestedGenericLine, intTypePos.character);
+        const intIsBuiltinType = intTypeScopes?.scopes?.some(scope => scope.includes('support.type'));
+        assert.ok(intIsBuiltinType, `'int' in array<int> should be a builtin type. Got scopes: ${JSON.stringify(intTypeScopes?.scopes)}`);
+
         console.log('✓ Function pointer parameter types test passed');
     });
 
@@ -1241,7 +1261,80 @@ suite('daScript Syntax Highlighting Tests', () => {
         );
         assert.ok(nodeIdIsType, `'NodeId' in lambda<NodeId> should be highlighted as a type. Got scopes: ${JSON.stringify(nodeIdScopes?.scopes)}`);
 
+        // Test 5: 'var' inside lambda signature should be a keyword, not a type
+        let varParamLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('lambda<(var urls')) {
+                varParamLine = i;
+                break;
+            }
+        }
+        assert.ok(varParamLine >= 0, 'Should find lambda signature with var parameter line');
+
+        const varParamPos = findInLine(document, varParamLine, 'var urls');
+        const varParamScopes = await getTokenScopesAt(document, varParamLine, varParamPos.character);
+        const varIsKeyword = varParamScopes?.scopes?.some(scope => scope.includes('storage.modifier'));
+        const varIsNotType = !varParamScopes?.scopes?.some(scope => scope.includes('entity.name.type'));
+        assert.ok(varIsKeyword && varIsNotType, `'var' in lambda signature should be a storage modifier, not a type. Got scopes: ${JSON.stringify(varParamScopes?.scopes)}`);
+
+        // 'array' in the nested generic should be a keyword.type, 'string' a type
+        const arrayPos = findInLine(document, varParamLine, 'array<string>');
+        const arrayScopes = await getTokenScopesAt(document, varParamLine, arrayPos.character);
+        const arrayIsKeywordType = arrayScopes?.scopes?.some(scope => scope.includes('keyword.type'));
+        assert.ok(arrayIsKeywordType, `'array' in lambda signature should be keyword.type. Got scopes: ${JSON.stringify(arrayScopes?.scopes)}`);
+
         console.log('✓ Lambda type templates test passed');
+    });
+
+    test('@@function references should highlight as function names', async () => {
+        const uri = vscode.Uri.file(
+            path.join(__dirname, '../../test/fixtures/function-pointers.das')
+        );
+
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        // Wait for tokenization to complete
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Test 1: @@on_lobby_created inside a call argument list
+        let callLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('set_lobby_callbacks(@@on_lobby_created')) {
+                callLine = i;
+                break;
+            }
+        }
+        assert.ok(callLine >= 0, 'Should find set_lobby_callbacks line');
+
+        const refPos = findInLine(document, callLine, 'on_lobby_created,');
+        const refScopes = await getTokenScopesAt(document, callLine, refPos.character);
+        const refIsFunction = refScopes?.scopes?.some(scope => scope.includes('entity.name.function'));
+        const refIsNotAnnotation = !refScopes?.scopes?.some(scope => scope.includes('annotation'));
+        assert.ok(refIsFunction && refIsNotAnnotation, `'on_lobby_created' after @@ should be a function name, not an annotation. Got scopes: ${JSON.stringify(refScopes?.scopes)}`);
+
+        // The comma after the reference must not be swallowed by an annotation region
+        const commaPos = findInLine(document, callLine, ', @@on_lobby_connected');
+        const commaScopes = await getTokenScopesAt(document, callLine, commaPos.character);
+        const commaIsClean = !commaScopes?.scopes?.some(scope => scope.includes('meta.annotation'));
+        assert.ok(commaIsClean, `',' after @@ref should not be inside an annotation region. Got scopes: ${JSON.stringify(commaScopes?.scopes)}`);
+
+        // Test 2: module-qualified reference @@events::on_update
+        let qualLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('@@events::on_update')) {
+                qualLine = i;
+                break;
+            }
+        }
+        assert.ok(qualLine >= 0, 'Should find @@events::on_update line');
+
+        const qualPos = findInLine(document, qualLine, 'events::on_update');
+        const qualScopes = await getTokenScopesAt(document, qualLine, qualPos.character);
+        const qualIsFunction = qualScopes?.scopes?.some(scope => scope.includes('entity.name.function'));
+        assert.ok(qualIsFunction, `'events::on_update' after @@ should be a function name. Got scopes: ${JSON.stringify(qualScopes?.scopes)}`);
+
+        console.log('✓ @@function references test passed');
     });
 
     test('Syntax in comments should be ignored and only highlighted as comment', async () => {
@@ -2181,6 +2274,169 @@ suite('daScript Syntax Highlighting Tests', () => {
         console.log('✓ Cast/reinterpret types test passed');
     });
 
+    test('Base types called as constructor casts should be highlighted as types', async () => {
+        const uri = vscode.Uri.file(
+            path.join(__dirname, '../../test/fixtures/cast-types.das')
+        );
+
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        // Wait for tokenization to complete
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Test 1: uint16(0)
+        let u16Line = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('uint16(0)')) {
+                u16Line = i;
+                break;
+            }
+        }
+        assert.ok(u16Line >= 0, 'Should find uint16(0) line');
+
+        const u16Pos = findInLine(document, u16Line, 'uint16');
+        const u16Scopes = await getTokenScopesAt(document, u16Line, u16Pos.character);
+        const u16IsType = u16Scopes?.scopes?.some(scope => scope.includes('support.type'));
+        assert.ok(u16IsType, `'uint16' in uint16(0) should be highlighted as a type. Got scopes: ${JSON.stringify(u16Scopes?.scopes)}`);
+
+        // Test 2: float(intValue)
+        let floatLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('float(intValue)')) {
+                floatLine = i;
+                break;
+            }
+        }
+        assert.ok(floatLine >= 0, 'Should find float(intValue) line');
+
+        const floatPos = findInLine(document, floatLine, 'float');
+        const floatScopes = await getTokenScopesAt(document, floatLine, floatPos.character);
+        const floatIsType = floatScopes?.scopes?.some(scope => scope.includes('support.type'));
+        assert.ok(floatIsType, `'float' in float(intValue) should be highlighted as a type. Got scopes: ${JSON.stringify(floatScopes?.scopes)}`);
+
+        // Test 3: float3(1.0, 2.0, 3.0)
+        let float3Line = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('float3(1.0, 2.0, 3.0)')) {
+                float3Line = i;
+                break;
+            }
+        }
+        assert.ok(float3Line >= 0, 'Should find float3(1.0, 2.0, 3.0) line');
+
+        const float3Pos = findInLine(document, float3Line, 'float3');
+        const float3Scopes = await getTokenScopesAt(document, float3Line, float3Pos.character);
+        const float3IsType = float3Scopes?.scopes?.some(scope => scope.includes('support.type'));
+        assert.ok(float3IsType, `'float3' in float3(...) should be highlighted as a type. Got scopes: ${JSON.stringify(float3Scopes?.scopes)}`);
+
+        // Test 4: range(10) should be a function call, not a type
+        let rangeCallLine = -1;
+        let rangeTypeLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            const lineText = document.lineAt(i).text;
+            if (rangeCallLine < 0 && lineText.includes('range(10)')) {
+                rangeCallLine = i;
+            }
+            if (rangeTypeLine < 0 && lineText.includes('var r : range')) {
+                rangeTypeLine = i;
+            }
+        }
+        assert.ok(rangeCallLine >= 0, 'Should find range(10) line');
+        assert.ok(rangeTypeLine >= 0, 'Should find var r : range line');
+
+        const rangeCallPos = findInLine(document, rangeCallLine, 'range');
+        const rangeCallScopes = await getTokenScopesAt(document, rangeCallLine, rangeCallPos.character);
+        const rangeIsFunction = rangeCallScopes?.scopes?.some(scope => scope.includes('entity.name.function'));
+        const rangeCallIsType = rangeCallScopes?.scopes?.some(scope => scope.includes('support.type'));
+        assert.ok(rangeIsFunction && !rangeCallIsType, `'range' in range(10) should be highlighted as a function call, not a type. Got scopes: ${JSON.stringify(rangeCallScopes?.scopes)}`);
+
+        const rangeTypePos = findInLine(document, rangeTypeLine, 'range');
+        const rangeTypeScopes = await getTokenScopesAt(document, rangeTypeLine, rangeTypePos.character);
+        const rangeIsType = rangeTypeScopes?.scopes?.some(scope =>
+            scope.includes('support.type') || scope.includes('entity.name.type')
+        );
+        assert.ok(rangeIsType, `'range' in 'var r : range' should still be highlighted as a type. Got scopes: ${JSON.stringify(rangeTypeScopes?.scopes)}`);
+
+        console.log('✓ Constructor cast types test passed');
+    });
+
+    test('qmacro_expr and reification tags should highlight correctly', async () => {
+        const uri = vscode.Uri.file(
+            path.join(__dirname, '../../test/fixtures/call-macro-annotations.das')
+        );
+
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        // Wait for tokenization to complete
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Test 1: qmacro_expr should be highlighted the same as qmacro_block
+        let qmacroBlockLine = -1;
+        let qmacroExprLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            const lineText = document.lineAt(i).text;
+            if (qmacroBlockLine < 0 && lineText.includes('qmacro_block <|')) {
+                qmacroBlockLine = i;
+            }
+            if (qmacroExprLine < 0 && lineText.includes('qmacro_expr <|')) {
+                qmacroExprLine = i;
+            }
+        }
+        assert.ok(qmacroBlockLine >= 0, 'Should find qmacro_block line');
+        assert.ok(qmacroExprLine >= 0, 'Should find qmacro_expr line');
+
+        const qmacroBlockPos = findInLine(document, qmacroBlockLine, 'qmacro_block');
+        const qmacroBlockScopes = await getTokenScopesAt(document, qmacroBlockLine, qmacroBlockPos.character);
+
+        const qmacroExprPos = findInLine(document, qmacroExprLine, 'qmacro_expr');
+        const qmacroExprScopes = await getTokenScopesAt(document, qmacroExprLine, qmacroExprPos.character);
+
+        const exprIsFunction = qmacroExprScopes?.scopes?.some(scope =>
+            scope.includes('entity.name.function')
+        );
+        assert.ok(exprIsFunction, `'qmacro_expr' should be highlighted as a function like qmacro_block. Got scopes: ${JSON.stringify(qmacroExprScopes?.scopes)}`);
+        assert.deepStrictEqual(qmacroExprScopes?.scopes, qmacroBlockScopes?.scopes,
+            `'qmacro_expr' should get the same scopes as 'qmacro_block'. qmacro_expr: ${JSON.stringify(qmacroExprScopes?.scopes)}, qmacro_block: ${JSON.stringify(qmacroBlockScopes?.scopes)}`);
+
+        // Test 2: reification tags $i / $e should be storage.modifier including the $ sign
+        let tagLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('for $i(iname) in $e(call.arguments[0])')) {
+                tagLine = i;
+                break;
+            }
+        }
+        assert.ok(tagLine >= 0, 'Should find line with $i and $e tags');
+
+        const lineText = document.lineAt(tagLine).text;
+
+        // Check both the '$' and the letter of '$i'
+        const dollarIIndex = lineText.indexOf('$i(');
+        for (const offset of [0, 1]) {
+            const scopes = await getTokenScopesAt(document, tagLine, dollarIIndex + offset);
+            const isStorageModifier = scopes?.scopes?.some(scope => scope.includes('storage.modifier'));
+            assert.ok(isStorageModifier, `'$i' (char ${offset}) should be storage.modifier. Got scopes: ${JSON.stringify(scopes?.scopes)}`);
+        }
+
+        // Check both the '$' and the letter of '$e'
+        const dollarEIndex = lineText.indexOf('$e(');
+        for (const offset of [0, 1]) {
+            const scopes = await getTokenScopesAt(document, tagLine, dollarEIndex + offset);
+            const isStorageModifier = scopes?.scopes?.some(scope => scope.includes('storage.modifier'));
+            assert.ok(isStorageModifier, `'$e' (char ${offset}) should be storage.modifier. Got scopes: ${JSON.stringify(scopes?.scopes)}`);
+        }
+
+        // The captured variable inside the tag should stay a variable, not storage.modifier
+        const inamePos = findInLine(document, tagLine, 'iname');
+        const inameScopes = await getTokenScopesAt(document, tagLine, inamePos.character);
+        const inameIsVariable = inameScopes?.scopes?.some(scope => scope.includes('variable'));
+        assert.ok(inameIsVariable, `'iname' inside $i() should be a variable. Got scopes: ${JSON.stringify(inameScopes?.scopes)}`);
+
+        console.log('✓ qmacro_expr and reification tags test passed');
+    });
+
     test('Module-qualified types (namespace::Type) should highlight namespace as type', async () => {
         const uri = vscode.Uri.file(
             path.join(__dirname, '../../test/fixtures/cast-types.das')
@@ -2261,6 +2517,52 @@ suite('daScript Syntax Highlighting Tests', () => {
         );
         assert.ok(isSmartPtrAstType, `'ast' in smart_ptr<ast::TypeDecl> should be highlighted as a type. Got scopes: ${JSON.stringify(smartPtrAstScopes?.scopes)}`);
         assert.ok(isNotVariantIdentifier, `'ast' in smart_ptr<ast::TypeDecl> should NOT be highlighted as a variant identifier. Got scopes: ${JSON.stringify(smartPtrAstScopes?.scopes)}`);
+
+        // Test 4: module-qualified variable on assignment LHS: user::userName = userName
+        let qualAssignLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('user::userName = userName')) {
+                qualAssignLine = i;
+                break;
+            }
+        }
+        assert.ok(qualAssignLine >= 0, 'Should find user::userName = userName line');
+
+        const qualVarPos = findInLine(document, qualAssignLine, 'userName =');
+        const qualVarScopes = await getTokenScopesAt(document, qualAssignLine, qualVarPos.character);
+        const qualVarIsVariable = qualVarScopes?.scopes?.some(scope => scope.includes('variable'));
+        const qualVarIsNotType = !qualVarScopes?.scopes?.some(scope => scope.includes('entity.name.type'));
+        assert.ok(qualVarIsVariable && qualVarIsNotType, `'userName' in 'user::userName =' should be a variable, not a type. Got scopes: ${JSON.stringify(qualVarScopes?.scopes)}`);
+
+        // Member access position: net::config.timeout
+        let memberLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('net::config.timeout')) {
+                memberLine = i;
+                break;
+            }
+        }
+        assert.ok(memberLine >= 0, 'Should find net::config.timeout line');
+
+        const memberPos = findInLine(document, memberLine, 'config');
+        const memberScopes = await getTokenScopesAt(document, memberLine, memberPos.character);
+        const memberIsVariable = memberScopes?.scopes?.some(scope => scope.includes('variable'));
+        assert.ok(memberIsVariable, `'config' in 'net::config.timeout' should be a variable. Got scopes: ${JSON.stringify(memberScopes?.scopes)}`);
+
+        // Function call position: net::send_message(...)
+        let qualCallLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('net::send_message(')) {
+                qualCallLine = i;
+                break;
+            }
+        }
+        assert.ok(qualCallLine >= 0, 'Should find net::send_message line');
+
+        const qualCallPos = findInLine(document, qualCallLine, 'send_message');
+        const qualCallScopes = await getTokenScopesAt(document, qualCallLine, qualCallPos.character);
+        const qualCallIsFunction = qualCallScopes?.scopes?.some(scope => scope.includes('entity.name.function'));
+        assert.ok(qualCallIsFunction, `'send_message' in 'net::send_message(...)' should be a function name. Got scopes: ${JSON.stringify(qualCallScopes?.scopes)}`);
 
         console.log('✓ Module-qualified types test passed');
     });

--- a/test/suite/syntax.test.js
+++ b/test/suite/syntax.test.js
@@ -1744,6 +1744,52 @@ suite('daScript Syntax Highlighting Tests', () => {
         console.log('✓ Table type arguments test passed');
     });
 
+    test('Block comments inside generic arguments should be highlighted as comments', async () => {
+        const uri = vscode.Uri.file(
+            path.join(__dirname, '../../test/fixtures/table-types.das')
+        );
+
+        const document = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(document);
+
+        // Wait for tokenization to complete
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // Find: var nodeNetIds : table<uint64 /*NodeId*/; uint /*netId*/>
+        let commentLine = -1;
+        for (let i = 0; i < document.lineCount; i++) {
+            if (document.lineAt(i).text.includes('table<uint64 /*NodeId*/; uint /*netId*/>')) {
+                commentLine = i;
+                break;
+            }
+        }
+        assert.ok(commentLine >= 0, 'Should find table with block comments in generic arguments');
+
+        // Verify 'NodeId' inside /*NodeId*/ is a comment, not a type
+        const nodeIdPos = findInLine(document, commentLine, 'NodeId');
+        const nodeIdScopes = await getTokenScopesAt(document, commentLine, nodeIdPos.character);
+        const nodeIdIsComment = nodeIdScopes?.scopes?.some(scope => scope.includes('comment'));
+        const nodeIdIsType = nodeIdScopes?.scopes?.some(scope => scope.includes('entity.name.type'));
+        assert.ok(nodeIdIsComment, `NodeId inside /*NodeId*/ should be a comment. Got scopes: ${JSON.stringify(nodeIdScopes?.scopes)}`);
+        assert.ok(!nodeIdIsType, `NodeId inside /*NodeId*/ should NOT be a type. Got scopes: ${JSON.stringify(nodeIdScopes?.scopes)}`);
+
+        // Verify 'netId' inside /*netId*/ is a comment
+        const netIdPos = findInLine(document, commentLine, 'netId*/');
+        const netIdScopes = await getTokenScopesAt(document, commentLine, netIdPos.character);
+        const netIdIsComment = netIdScopes?.scopes?.some(scope => scope.includes('comment'));
+        assert.ok(netIdIsComment, `netId inside /*netId*/ should be a comment. Got scopes: ${JSON.stringify(netIdScopes?.scopes)}`);
+
+        // Verify 'uint64' is still highlighted as a type
+        const uint64Pos = findInLine(document, commentLine, 'uint64');
+        const uint64Scopes = await getTokenScopesAt(document, commentLine, uint64Pos.character);
+        const uint64IsType = uint64Scopes?.scopes?.some(scope =>
+            scope.includes('support.type') || scope.includes('entity.name.type')
+        );
+        assert.ok(uint64IsType, `uint64 should still be highlighted as a type. Got scopes: ${JSON.stringify(uint64Scopes?.scopes)}`);
+
+        console.log('✓ Block comments inside generic arguments test passed');
+    });
+
     test('Annotations should be highlighted correctly', async () => {
         const uri = vscode.Uri.file(
             path.join(__dirname, '../../test/fixtures/annotations.das')


### PR DESCRIPTION
- fix block comments inside generic type arguments highlighted as types
- fix highlighting of range(), @@func refs, module-qualified names, and generics in function signatures
- range() calls highlight as function calls, not types
- var/let and nested generics (array<string>) highlight correctly inside
  lambda/function/block signature types, both in generic_types and template paths
- @@func and @@module::func address-of references highlight as function names
  instead of being swallowed by the property-annotation rule
- module:: prefix is now consumed as a namespace token only; the name after it
  is tokenized by the surrounding context rules (variables, function calls, types)